### PR TITLE
make it work with BSEC_1.4.8.0_Generic_Release_updated_v3

### DIFF
--- a/make.config
+++ b/make.config
@@ -1,4 +1,4 @@
-BSEC_DIR='./src/BSEC_1.4.8.0_Generic_Release'
+BSEC_DIR='./src/BSEC_1.4.8.0_Generic_Release_updated_v3'
 
 VERSION='normal_version'
 


### PR DESCRIPTION
The older 1.4.8.0 release seems not to be available anymore from Bosch. Path in current 1.4.8.0 differs.